### PR TITLE
Fixing the issues caused because of git rebase

### DIFF
--- a/monster/monster.go
+++ b/monster/monster.go
@@ -116,25 +116,10 @@ func generate(text []byte, count int, prodfile string, outch chan<- []byte) {
 	// verify the sanity of json generated from production file
 	var value map[string]interface{}
 	if options.json {
-<<<<<<< HEAD
 		scope = scope.RebuildContext()
 		val := evaluate("root", scope, nterms[options.nonterm])
 		if err := json.Unmarshal([]byte(val.(string)), &value); err != nil {
-			log.Printf("Invalid JSON %v\n", err)
-			os.Exit(1)
-		} else {
-			outch <- []byte(val.(string))
-		}
-	}
-
-	for i := 0; i < count; i++ {
-=======
->>>>>>> acbd395d2c0dfbee05855b853ae02015f67f209c
-		scope = scope.RebuildContext()
-		val := evaluate("root", scope, nterms[options.nonterm])
-		if err := json.Unmarshal([]byte(val.(string)), &value); err != nil {
-			log.Printf("Invalid JSON %v\n", err)
-			os.Exit(1)
+			log.Fatalf("Invalid JSON %v\n", err)
 		} else {
 			outch <- []byte(val.(string))
 		}


### PR DESCRIPTION
Apologies for introducing the issues because of git rebase and breaking monster.

Output from latest fixes:

```
➜  monster git:(master) ✗ ./monster -bagdir ../bags -count 1000 -o out -par=10 -json=true ../prods/fast1K.prod
Completed !!
➜  monster git:(master) ✗ grep '"type"' out | wc -l
   10000
➜  monster git:(master) ✗ ./monster -bagdir ../bags -count 1000 -o out -par=10 -json=true ../prods/invalid-json.prod 
2015/09/07 14:17:57 Invalid JSON invalid character '"' after object key:value pair
```
